### PR TITLE
Prevent palette color changing

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xls/Workbook.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Workbook.php
@@ -332,20 +332,26 @@ class Workbook extends BIFFwriter
     private function addColor($rgb)
     {
         if (!isset($this->colors[$rgb])) {
-            if (count($this->colors) < 57) {
-                // then we add a custom color altering the palette
-                $colorIndex = 8 + count($this->colors);
-                $this->palette[$colorIndex] =
-                    [
-                        hexdec(substr($rgb, 0, 2)),
-                        hexdec(substr($rgb, 2, 2)),
-                        hexdec(substr($rgb, 4)),
-                        0,
-                    ];
+            $color =
+                [
+                    hexdec(substr($rgb, 0, 2)),
+                    hexdec(substr($rgb, 2, 2)),
+                    hexdec(substr($rgb, 4)),
+                    0,
+                ];
+            $colorIndex = array_search($color, $this->palette);
+            if (isset($colorIndex)) {
                 $this->colors[$rgb] = $colorIndex;
             } else {
-                // no room for more custom colors, just map to black
-                $colorIndex = 0;
+                if (count($this->colors) < 57) {
+                    // then we add a custom color altering the palette
+                    $colorIndex = 8 + count($this->colors);
+                    $this->palette[$colorIndex] = $color;
+                    $this->colors[$rgb] = $colorIndex;
+                } else {
+                    // no room for more custom colors, just map to black
+                    $colorIndex = 0;
+                }
             }
         } else {
             // fetch already added custom color


### PR DESCRIPTION
For preventing color changing when origin xl97 palette color is good.

This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?
Dont create new color in palette (xl97) if color already exist.