### PR TITLE
Update order when addColor in palette

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xls/Workbook.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Workbook.php
@@ -340,12 +340,17 @@ class Workbook extends BIFFwriter
                     0,
                 ];
             $colorIndex = array_search($color, $this->palette);
-            if (isset($colorIndex)) {
+            if ($colorIndex) {
                 $this->colors[$rgb] = $colorIndex;
             } else {
-                if (count($this->colors) < 57) {
+                if(count($this->colors) == 0){
+                    $lastColor = 7;
+                }else{
+                    $lastColor = end($this->colors);
+                }
+                if ($lastColor < 57) {
                     // then we add a custom color altering the palette
-                    $colorIndex = 8 + count($this->colors);
+                    $colorIndex = $lastColor + 1;
                     $this->palette[$colorIndex] = $color;
                     $this->colors[$rgb] = $colorIndex;
                 } else {

--- a/tests/PhpSpreadsheetTests/Writer/Xls/WorkbookTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/WorkbookTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: youri
+ * Date: 10/09/2017
+ * Time: 10:43
+ */
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xls\Workbook;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xls\Parser;
+use PhpOffice\PhpSpreadsheet\Writer\Xls\Workbook;
+use PHPUnit_Framework_TestCase;
+
+class WorkbookTest extends PHPUnit_Framework_TestCase
+{
+
+    private $workbook;
+
+
+    protected function setUp(){
+        $spreadsheet = new Spreadsheet();
+        $strTotal = 0;
+        $strUnique = 0;
+        $str_table = [];
+        $colors = [];
+        $parser = new Parser();
+
+        $this->workbook = new Workbook($spreadsheet, $strTotal, $strUnique, $str_table, $colors,$parser);
+    }
+
+    protected function tearDown()
+    {
+        $this->workbook = null;
+    }
+
+    /**
+     * @dataProvider providerAddColor
+     *
+     * @param mixed $expectedResult
+     */
+    public function testAddColor($testColors,$expectedResult){
+        $result = 0;
+
+        $workbookReflection = new \ReflectionClass(Workbook::class);
+        $methodAddColor = $workbookReflection->getMethod('addColor');
+        $propertyPalette = $workbookReflection->getProperty('palette');
+        $methodAddColor->setAccessible(TRUE);
+        $propertyPalette->setAccessible(TRUE);
+
+        foreach($testColors as $testColor){
+            $result = $methodAddColor->invoke($this->workbook, $testColor);
+        }
+
+        $palette = $propertyPalette->getValue($this->workbook);
+
+        $this->assertEquals($expectedResult, $palette);
+    }
+
+    public function providerAddColor(){
+        $this->setUp();
+
+        $workbookReflection = new \ReflectionClass(Workbook::class);
+        $propertyPalette = $workbookReflection->getProperty('palette');
+        $propertyPalette->setAccessible(true);
+
+        $palette = $propertyPalette->getValue($this->workbook);
+
+        $newColor_1 = [0x00, 0x00, 0x01, 0x00];
+        $newColor_2 = [0x00, 0x00, 0x02, 0x00];
+        $newColor_3 = [0x00, 0x00, 0x03, 0x00];
+
+        // Add one new color
+        $paletteTestOne = $palette;
+        $paletteTestOne[8] = $newColor_1;
+
+        // Add one new color + one existing color after index 8
+        $paletteTestTwo = $paletteTestOne;
+
+        // Add one new color + one existing color before index 9
+        $paletteTestThree = $paletteTestOne;
+        $paletteTestThree[9] = $palette[8];
+
+        // Add three new color
+        $paletteTestFour = $palette;
+        $paletteTestFour[8] = $newColor_1;
+        $paletteTestFour[9] = $newColor_2;
+        $paletteTestFour[10] = $newColor_3;
+
+        // Add all existing color
+        $colorsAdd = array_map('self::paletteToColor', $palette);
+        $paletteTestFive = $palette;
+
+        // Add new color after all existing color
+        $colorsAddTwo = array_map('self::paletteToColor', $palette);
+        array_push($colorsAddTwo, self::paletteToColor($newColor_1));
+        $paletteTestSix = $palette;
+
+        // Add one existing color
+        $paletteTestSeven = $palette;
+
+        // Add two existing color
+        $paletteTestHeight = $palette;
+
+        // Add last existing color and add one new color
+        $keyPalette = array_keys($palette);
+        $last = end($keyPalette);
+        $lastColor = $this->paletteToColor($palette[$last]);
+        $paletteTestNine = $palette;
+
+        return [
+            [[self::paletteToColor($newColor_1)], $paletteTestOne],
+            [[self::paletteToColor($newColor_1), self::paletteToColor($palette[12])], $paletteTestTwo],
+            [[self::paletteToColor($newColor_1), self::paletteToColor($palette[8])], $paletteTestThree],
+            [[$this->paletteToColor($newColor_1), $this->paletteToColor($newColor_2), $this->paletteToColor($newColor_3)], $paletteTestFour],
+            [$colorsAdd, $paletteTestFive],
+            [$colorsAddTwo, $paletteTestSix],
+            [[self::paletteToColor($palette[8])], $paletteTestSeven],
+            [[self::paletteToColor($palette[25]), self::paletteToColor($palette[10])], $paletteTestHeight],
+            [[$lastColor, self::paletteToColor($newColor_1)], $paletteTestNine],
+        ];
+    }
+
+    /**
+     * Change palette color to rgb string
+     *
+     * @param array $palette palette color
+     * @return string rgb string
+     */
+    public static function paletteToColor($palette){
+        return self::right('00'.dechex(intval($palette[0])),2)
+            .self::right('00'.dechex(intval($palette[1])),2)
+            .self::right('00'.dechex(intval($palette[2])),2);
+    }
+
+    /**
+     * Return n right character in string
+     *
+     * @param string $value text tu get right character
+     * @param integer $nbchar number of char at right of string
+     * @return string
+     */
+    public static function right($value,$nbchar)
+    {
+            return mb_substr($value,mb_strlen($value)-$nbchar, $nbchar);
+    }
+}


### PR DESCRIPTION
Update order when addColor in palette
Better than previously set

This is:

- [X] a bugfix
- [ ] a new feature

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?
Order of collor add don't errase original color in palette if exist in workbook